### PR TITLE
Solve rpclog problem

### DIFF
--- a/lib/rpc-client/client.js
+++ b/lib/rpc-client/client.js
@@ -174,7 +174,7 @@ pro.rpcInvoke = function(serverId, msg, cb) {
     cb(new Error('[pomelo-rpc] fail to do rpc invoke for client is not running'));
     return;
   }
-  this._station.dispatch(tracer, serverId, msg, null, cb);
+  this._station.dispatch(tracer, serverId, msg, this.opts, cb);
 };
 
 pro.before = function(filter) {


### PR DESCRIPTION
When the rpc-log is on, the rpc information cannot write to rpclog files.
Because of this, the web of pomelo-web-admin will show empty information in related items.
